### PR TITLE
Go back to one page for logged in and logged out.

### DIFF
--- a/helloworld/src/App.tsx
+++ b/helloworld/src/App.tsx
@@ -14,7 +14,6 @@ import Header from "./components/Header";
 import NotificationBell from "./components/NotificationBell";
 import UserMenu from "./components/UserMenu";
 import Settings from "./components/Settings";
-import LoggedOutPage from "./components/LoggedOutPage";
 
 const App: React.FC = () => {
   const isStaging = process.env.REACT_APP_ENVIRONMENT === "staging";
@@ -24,7 +23,6 @@ const App: React.FC = () => {
       <Router>
         <UserDataProvider>
           <Routes>
-            <Route path="/" element={<LoggedOutPage />} />
             <Route
               element={
                 <GrindOlympiadsLayout
@@ -35,7 +33,7 @@ const App: React.FC = () => {
                 />
               }
             >
-              <Route path="/home" element={<GrindOlympiadsIndex />} />
+              <Route index element={<GrindOlympiadsIndex />} />
               <Route
                 path="competition/:competition/:year/:exam"
                 element={<ExamComponent />}

--- a/helloworld/src/GrindOlympiadsIndex.tsx
+++ b/helloworld/src/GrindOlympiadsIndex.tsx
@@ -5,6 +5,7 @@ import TestList from "./components/TestList";
 import UserProgress from "./components/UserProgress";
 import useUserData from "./hooks/useUserData";
 import useTests from "./hooks/useTests";
+import LoggedOutPage from "./components/LoggedOutPage";
 
 const GrindOlympiadsIndex: React.FC = () => {
   const [showTests, setShowTests] = useState<boolean>(false);
@@ -19,6 +20,10 @@ const GrindOlympiadsIndex: React.FC = () => {
     setSelectedCompetition,
     filteredTests,
   } = useTests();
+
+  if (!isLoggedIn) {
+    return <LoggedOutPage />;
+  }
 
   if (loading) {
     return (
@@ -42,15 +47,9 @@ const GrindOlympiadsIndex: React.FC = () => {
       <Hero showTests={showTests} setShowTests={setShowTests} />
 
       <div className="container mx-auto py-8">
-        {isLoggedIn ? (
-          <h2 className="text-2xl font-bold mb-4">
-            Welcome, {user?.name || "User"}!
-          </h2>
-        ) : (
-          <h2 className="text-2xl font-bold mb-4">
-            Please log in to access all features.
-          </h2>
-        )}
+        <h2 className="text-2xl font-bold mb-4">
+          Welcome, {user?.name || "User"}!
+        </h2>
       </div>
 
       {showTests && (
@@ -65,7 +64,7 @@ const GrindOlympiadsIndex: React.FC = () => {
           <TestList tests={filteredTests} />
         </>
       )}
-      {isLoggedIn && <UserProgress userProgress={userProgress} />}
+      <UserProgress userProgress={userProgress} />
     </div>
   );
 };

--- a/helloworld/src/components/LoggedOutPage.tsx
+++ b/helloworld/src/components/LoggedOutPage.tsx
@@ -1,18 +1,5 @@
-import React, { useState, forwardRef } from "react";
-import Header from "./Header";
-import { NotificationBellProps } from "./NotificationBell";
-import { UserMenuProps } from "./UserMenu";
+import React, { useState } from "react";
 import "../LoggedOutPage.css";
-
-const MockNotificationBell = forwardRef<HTMLDivElement, NotificationBellProps>(
-  (props, ref) => {
-    return <div ref={ref}></div>;
-  },
-);
-
-const MockUserMenu = forwardRef<HTMLDivElement, UserMenuProps>((props, ref) => {
-  return <div ref={ref}></div>;
-});
 
 const LoggedOutPage: React.FC = () => {
   const [selectedGoals, setSelectedGoals] = useState<string[]>([]);
@@ -119,13 +106,6 @@ const LoggedOutPage: React.FC = () => {
 
   return (
     <div className="logged-out-page">
-      <Header
-        notifications={[]}
-        notificationsError={null}
-        markNotificationAsRead={() => {}}
-        NotificationBell={MockNotificationBell}
-        UserMenu={MockUserMenu}
-      />
       <main>
         <section className="hero">
           <h1>Personalized Math Competition Training</h1>


### PR DESCRIPTION
We got into kindof a goofy spot having one route for logged in and one route for logged out. Revert back to the pattern of having GrindOlympiadsIndex handle both cases, which makes a smoother transition between logging in and out (i.e. don't randomly wind up on the wrong URL).